### PR TITLE
HTTP Server:  Added ability to select core

### DIFF
--- a/components/esp_http_server/include/esp_http_server.h
+++ b/components/esp_http_server/include/esp_http_server.h
@@ -34,6 +34,7 @@ initializer that should be kept in sync
 #define HTTPD_DEFAULT_CONFIG() {                        \
         .task_priority      = tskIDLE_PRIORITY+5,       \
         .stack_size         = 4096,                     \
+        .core_id            = tskNO_AFFINITY,           \
         .server_port        = 80,                       \
         .ctrl_port          = 32768,                    \
         .max_open_sockets   = 7,                        \
@@ -139,6 +140,7 @@ typedef bool (*httpd_uri_match_func_t)(const char *reference_uri,
 typedef struct httpd_config {
     unsigned    task_priority;      /*!< Priority of FreeRTOS task which runs the server */
     size_t      stack_size;         /*!< The maximum stack size allowed for the server task */
+    BaseType_t  core_id;            /*!< The core the HTTP server task will run on */
 
     /**
      * TCP Port number for receiving and transmitting HTTP traffic

--- a/components/esp_http_server/src/httpd_main.c
+++ b/components/esp_http_server/src/httpd_main.c
@@ -363,7 +363,8 @@ esp_err_t httpd_start(httpd_handle_t *handle, const httpd_config_t *config)
     if (httpd_os_thread_create(&hd->hd_td.handle, "httpd",
                                hd->config.stack_size,
                                hd->config.task_priority,
-                               httpd_thread, hd) != ESP_OK) {
+                               httpd_thread, hd, 
+                               hd->config.core_id) != ESP_OK) {
         /* Failed to launch task */
         httpd_delete(hd);
         return ESP_ERR_HTTPD_TASK;

--- a/components/esp_http_server/src/port/esp32/osal.h
+++ b/components/esp_http_server/src/port/esp32/osal.h
@@ -32,9 +32,10 @@ typedef TaskHandle_t othread_t;
 
 static inline int httpd_os_thread_create(othread_t *thread,
                                  const char *name, uint16_t stacksize, int prio,
-                                 void (*thread_routine)(void *arg), void *arg)
+                                 void (*thread_routine)(void *arg), void *arg,
+                                 BaseType_t core_id)
 {
-    int ret = xTaskCreate(thread_routine, name, stacksize, arg, prio, thread);
+    int ret = xTaskCreatePinnedToCore(thread_routine, name, stacksize, arg, prio, thread, core_id);
     if (ret == pdPASS) {
         return OS_SUCCESS;
     }


### PR DESCRIPTION
The task that runs the HTTP server can now be pinned to a particular core by setting `core_id` in the HTTP server configuration.  By default, the core is set to `tskNO_AFFINITY`, meaning it can run on any core.